### PR TITLE
Jbcheung fix bot rotation

### DIFF
--- a/GameFrame/RoomObject.py
+++ b/GameFrame/RoomObject.py
@@ -213,10 +213,7 @@ class RoomObject:
 
     def rotate(self, angle):
 
-        if self.curr_rotation > 360:
-            self.curr_rotation = self.curr_rotation - 360
-        elif self.curr_rotation < 0:
-            self.curr_rotation = 350 - self.curr_rotation
+        self.curr_rotation%=360
 
         self.curr_rotation = self.angle = angle + self.curr_rotation
 

--- a/Rooms/Arena.py
+++ b/Rooms/Arena.py
@@ -26,7 +26,6 @@ class Arena(Level):
 
         for i in range(len(Globals.blue_bots)):
             self.add_room_object(Globals.blue_bots[i])
-            Globals.blue_bots[i].rotate(180)
 
         Globals.red_flag = RedFlag(self, 200, Globals.SCREEN_HEIGHT / 2 - 26)
         Globals.blue_flag = BlueFlag(self, Globals.SCREEN_WIDTH - 232, Globals.SCREEN_HEIGHT / 2 - 26)


### PR DESCRIPTION
This fixes operations done to self.curr_rotation in bots outputting a non-equivalent angle when the bot's rotation is negative (namely, in blue bots at the beginning of the game) before rotating in RoomObject.rotate()